### PR TITLE
fix(ci): fix upgrade workflow permissions

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -12,9 +12,12 @@ jobs:
   upgrade_provider:
     name: upgrade-provider
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Call upgrade provider action
         uses: pulumi/pulumi-upgrade-provider-action@main
         with:
-          username: omercnet
           kind: bridge


### PR DESCRIPTION
https://github.com/pulumiverse/pulumi-vercel/actions/runs/6002258821/job/16278245430 fails due to lack of permissions

@ringods please make sure [github actions is allowed to open PRs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests) in this repo