### PR TITLE
Update pulumi/vercel to pulumiverse/vercel

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -8,11 +8,10 @@ layout: package
 
 The Vercel provider is available as a package in all Pulumi languages:
 
-* JavaScript/TypeScript: [`@pulumi/vercel`](https://www.npmjs.com/package/@pulumi/vercel)
-* Python: [`pulumi-vercel`](https://pypi.org/project/pulumi-vercel/)
-* Go: [`github.com/pulumiverse/pulumi-vercel/sdk/v3/go/vercel`](https://github.com/pulumi/pulumi-vercel)
-* .NET: [`Pulumi.Vercel`](https://www.nuget.org/packages/Pulumi.Vercel)
-* Java: [`com.pulumi/vercel`](https://central.sonatype.com/artifact/com.pulumi/vercel)
+* JavaScript/TypeScript: [`@pulumiverse/vercel`](https://www.npmjs.com/package/@pulumiverse/vercel)
+* Python: [`pulumiverse-vercel`](https://pypi.org/project/pulumiverse-vercel/)
+* Go: [`github.com/pulumiverse/pulumi-vercel/sdk`](https://pkg.go.dev/github.com/pulumiverse/pulumi-vercel/sdk)
+* .NET: [`Pulumiverse.vercel`](https://www.nuget.org/packages/Pulumiverse.vercel)
 ## Overview
 
 The Vercel provider is used to interact with resources supported by Vercel.


### PR DESCRIPTION
Changed the sdk urls to the correct ones. Also the Java sdk doesn't seem to exists.